### PR TITLE
Add education and internship sections

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,16 +4,33 @@ layout: homepage
 
 ## About Me
 
-I am a undergraduate student at the School of Information Science and Technology, ShanghaiTech University.  
+I am a graduate student in the MS in Information Systems program at New York University. I received my B.S. from the School of Information Science and Technology, ShanghaiTech University.
 
 ## Research Interests
 
 - **Computer Vision**
 
+## Education
+
+- **New York University**, M.S. in Information Systems (Sep. 2025 – Present)  
+  Joint program between the Courant (GSAS) and the Stern School of Business, combining computer science and business courses.
+- **ShanghaiTech University**, B.S. in Computer Science and Technology (Sep. 2021 – Jun. 2025)  
+  GPA: 3.44/4.0. Outstanding Student (2023‑2024); Outstanding Award in the First Admissions Promotion Project Competition (2022); Outstanding Individual in Undergraduate Social Practice (2022).
+- **University of California, Berkeley**, Global Exchange Program in Computer Science (Aug. 2023 – May. 2024)  
+  Courses: Designing, Visualizing and Understanding Deep Neural Networks; Intro to Computer Vision and Computational Photography.
+
+## Internship Experience
+
+- **Hundsun Technologies Inc.**, Junior Software Engineer Intern (May. 2024 – Jul. 2024)  
+  - Conducted research on datasets and models for document layout analysis.  
+  - Evaluated open-source models on the Chinese dataset CDLA.  
+  - Retrained LayoutLMv3, YOLO, and VGT models and compared their performance.
+
 ## News
 
 - **[Dec. 2024]** Recognized as an <strong>Outstanding Student</strong>, 2023-2024!
-- **[Feb. 2024]** First paper in life accepted by <strong>CVPR 2024</strong>! <small> albeit as third author.</small> 
+- **[Jul. 2024]** Completed internship at <strong>Hundsun Technologies</strong> as a Junior Software Engineer.
+- **[Feb. 2024]** First paper in life accepted by <strong>CVPR 2024</strong>! <small> albeit as third author.</small>
 
 {% include_relative _includes/publications.md %}
 


### PR DESCRIPTION
## Summary
- Expand about section with NYU MSIS studies and ShanghaiTech background
- Add Education and Internship Experience sections to highlight academic and work history
- Record internship completion in News

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b846f645608324b69a68f38eb008fa